### PR TITLE
Human-anchor annotation UX: navigator, resume, and local serve mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ orq-arena is that missing layer. It runs a round-robin over any pool of models r
 - **A live show worth projecting**: a CRT-neon TUI with streaming responses, judge cards that call out position-biased votes in public, HP drama, live standings.
 - **Real benchmark data out the back**: every round lands in `battles.jsonl` (schema v2) with both responses, reconciled per-judge votes, exact token/reasoning-token usage, TTFT.
 - **Jury swaps without regeneration**: re-judge any recorded run with a different panel and get a rank-stability answer (Spearman).
+- **A human anchor in one file**: `annotate` renders any recorded run into a blind browser page (no names, no jury votes, seeded side swaps); send it to raters, feed their `votes.json` to `anchor`, and get panel-vs-human κ plus rank correlation.
 - **Headless for CI/cron**: same benchmark, parallel matches, no TUI.
 
 ## Installation
@@ -63,7 +64,7 @@ When you are ready for a live run against real models:
 
 ## Usage
 
-**Run a tournament**: `uv run orq-arena run` opens the interactive roster picker; add `--config orq_arena.yaml` to run the YAML roster as-is, or `--headless --yes` for CI/cron (no TUI, matches run in parallel). Full flag reference: **[docs/cli.md](docs/cli.md)**.
+**Run a tournament**: `uv run orq-arena run` opens the interactive roster picker; add `--config orq_arena.yaml` to run the YAML roster as-is, or `--headless --yes` for CI/cron (no TUI, matches run in parallel). `--prompts` takes a local JSONL or `orq:<dataset_id>` to fight over a [Dataset](https://docs.orq.ai/docs/ai-studio/optimize/datasets) straight from your workspace. Full flag reference: **[docs/cli.md](docs/cli.md)**.
 
 **Browse the results**: from the final leaderboard, `B` pages through every judged round (prompt, both responses, per-judge votes with flip badges); `M` generates per-model coach notes from an analyzer model.
 
@@ -108,7 +109,7 @@ Full guides live in [`docs/`](docs/); start with the [docs index](docs/README.md
 | Guide | Description |
 |-------|-------------|
 | [Getting Started](docs/getting-started.md) | Prerequisites, install, first live run, common setup issues |
-| [CLI Reference](docs/cli.md) | Every command and flag, `run`, `demo`, `rejudge`, `list-warriors`, `refresh-models` |
+| [CLI Reference](docs/cli.md) | Every command and flag, `run`, `demo`, `rejudge`, `report`, `list-warriors`, `refresh-models` |
 | [Configuration](docs/configuration.md) | Every `orq_arena.yaml` key, reasoning recipes, defaults |
 | [Methodology](docs/methodology.md) | Bradley-Terry scoring, bias controls, confidence intervals, reproducibility |
 | [Architecture](docs/architecture.md) | Component overview, data flow, key abstractions |

--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -306,3 +306,8 @@ tokens ≈ 8× warrior tokens under both-orders judging; cheap judges flip 67–
 29. Blinding contract for annotation: the generated page ships no model names, no jury votes,
     no verdicts; round keys are one-way hashes; side order flips per round by seeded RNG; human
     votes are stored in the canonical A/B frame so merges never depend on presentation order.
+30. Two transports, one page: `annotate --serve` adds a Prodigy-style localhost mode (stdlib
+    `http.server`, binds 127.0.0.1 only, votes POST to /save and land next to the log, Ctrl-C
+    prints the anchor table) for the operator annotating their own run; the static-file mode
+    stays the transport for remote raters. Same page, same votes.json schema either way.
+    FastAPI/hosted serving stays rejected until multi-rater assignment logic exists.

--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -120,7 +120,7 @@ Spearman vs the recorded ranking, inconclusive rate, agreement, worst per-judge 
 rate, changed verdicts. Everything it measures is reliability; the accuracy axis (which jury
 is *right*, not just consistent) arrives with PR 11's gold-pair sanity suite and human anchor.
 
-### G5: Human anchor *(PR 11.4 pulled forward, decisions 28-29)*
+### G5: Human anchor *(PR 11.4 pulled forward, decisions 28-29)*. **TOOLING SHIPPED 2026-07-12, study pending**
 Blind web annotation of a recorded run, merged back into panel↔human κ and rank correlation;
 the launch-worthy accuracy number ("panel agrees with humans at κ=X"). Two commands, no server:
 `orq-arena annotate <log>` renders one self-contained blinded page (no model names, no jury
@@ -128,8 +128,13 @@ votes, seeded side order; votes export as `votes.json`); `orq-arena anchor <log>
 prints per-annotator Cohen's κ vs the panel majority, Spearman of BT(human) vs BT(panel), and
 inter-annotator κ. Explicitly a web artifact, not a TUI screen: annotation is a reading task,
 raters may not live in terminals, and blinding is only real when names never enter the page.
-Full task-level plan: `.planning/plans/2026-07-12-human-anchor.md`. Target: 50–100 rounds,
-2–3 raters, results into methodology docs (PR 12.2 consumes them).
+Full task-level plan: `.planning/plans/2026-07-12-human-anchor.md`.
+**Shipped** (`src/orq_arena/anchor.py`, 16 tests): both commands, page with intro/guidelines
+(round count, time estimate, `--criteria` rubric, rater name) → blind duel → explicit done
+screen with download (first-rater feedback: the auto-download surprised; fixed same day).
+The blindness contract is test-enforced (`test_page_is_blind` even bans the substring
+"judge" from the page). **Remaining: the study itself**, 50–100 rounds, 2–3 raters, results
+into methodology docs (PR 12.2 consumes them).
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -405,8 +405,11 @@ and two anonymous responses; votes go by `a` (left better), `b` (right better), 
 `space` (skip), arrows to navigate; markdown and code fences render properly. After the last
 round a **done screen** shows how many rounds were voted vs skipped and holds the explicit
 "Download votes.json" button (plus a leave-warning while votes are undownloaded; left arrow
-goes back to revisit skips). Exported votes are already un-flipped to the canonical A/B
-frame, so the vote file is independent of presentation order.
+goes back to revisit skips). A persistent header count (voted / skipped / left) and a
+clickable per-round dot navigator (voted, tie, skipped, unseen, current) keep position
+visible at all times; `n` jumps to the next unvoted round. Exported votes are already
+un-flipped to the canonical A/B frame, so the vote file is independent of presentation
+order.
 
 ```bash
 uv run orq-arena annotate outputs/g1/battles.jsonl --sample 60

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,6 +33,8 @@ full `orq_arena.yaml` key reference, see [configuration.md](configuration.md).
 | [`rejudge`](#rejudge) | Re-score a recorded `battles.jsonl` with a different judge panel, zero regeneration. |
 | [`report`](#report) | Render the single-file HTML report page from a recorded run; no API calls. |
 | [`jury-compare`](#jury-compare) | Tabulate candidate juries from saved rejudge reports, side by side; no API calls. |
+| [`annotate`](#annotate) | Render a blinded human-annotation page from a recorded run; no API calls. |
+| [`anchor`](#anchor) | Merge human vote files back against a run: panel↔human κ + rank correlation; no API calls. |
 | [`refresh-models`](#refresh-models) | Force re-fetch of the 24h workspace model-catalog cache. |
 
 ---
@@ -370,6 +372,70 @@ manifest hashes for reproducibility.
 ```bash
 uv run orq-arena report outputs/g1/battles.jsonl
 uv run orq-arena report battles.jsonl --output /tmp/run.html
+```
+
+## `annotate`
+
+Render a blinded human-annotation page from a recorded run. Reads `battles.jsonl`; makes no
+API calls. This is the front half of the human-anchor workflow (the back half is
+[`anchor`](#anchor)): the accuracy check that converts "the panel agrees with itself" into
+"the panel agrees with people" (see
+[Methodology → Human anchor](methodology.md#human-anchor-does-the-panel-agree-with-people)).
+
+```text
+orq-arena annotate BATTLE_LOG [--out PATH] [--sample N] [--seed N]
+```
+
+| Flag / arg | Default | Effect |
+|---|---|---|
+| `BATTLE_LOG` (positional) | required | The recorded run to annotate. |
+| `--out PATH` | `annotate.html` | Destination HTML file. |
+| `--sample N` | all rounds | Annotate a seeded random subset instead of every round. |
+| `--seed N` | `42` | Drives round order and per-round side flips; keep it if you want two raters on identical pages. |
+
+The page is one self-contained HTML file (inline CSS/JS, no external assets, works from
+`file://`), so "deployment" is sending someone the file. It is **blind by construction**:
+model names, jury votes, and verdicts never enter the payload; rounds are shuffled and the
+two responses swap sides per round under the seed; round keys are one-way hashes.
+
+The rater's flow has three views. An **intro** states what the task is, the round count, a
+rough time estimate, the criteria to weigh (`--criteria`, defaulting to the jury's default
+rubric), the key legend, and asks for their name. The **annotation view** shows one prompt
+and two anonymous responses; votes go by `a` (left better), `b` (right better), `t` (tie),
+`space` (skip), arrows to navigate; markdown and code fences render properly. After the last
+round a **done screen** shows how many rounds were voted vs skipped and holds the explicit
+"Download votes.json" button (plus a leave-warning while votes are undownloaded; left arrow
+goes back to revisit skips). Exported votes are already un-flipped to the canonical A/B
+frame, so the vote file is independent of presentation order.
+
+```bash
+uv run orq-arena annotate outputs/g1/battles.jsonl --sample 60
+uv run orq-arena annotate battles.jsonl --out rater2.html --seed 42
+```
+
+## `anchor`
+
+Merge one or more human vote files back against the recorded run and print the human-anchor
+numbers; no API calls.
+
+```text
+orq-arena anchor BATTLE_LOG VOTES_JSON [VOTES_JSON ...]
+```
+
+| Flag / arg | Default | Effect |
+|---|---|---|
+| `BATTLE_LOG` (positional) | required | The same log the annotation page was generated from. |
+| `VOTES_JSON` (positional, repeatable) | required | Vote files exported by the annotation page, one per rater. |
+
+Output, per annotator: rounds voted, rounds usable for κ (the panel must have been decisive;
+inconclusive rounds are excluded from κ but still feed the human Bradley-Terry fit), Cohen's
+κ vs the panel majority with its Landis-Koch label, and the Spearman correlation between the
+human-vote Bradley-Terry ranking and the panel's. With two or more vote files it also prints
+each rater pair's inter-annotator κ over their shared rounds. Votes whose key matches no
+round in the log are counted and warned, never crash.
+
+```bash
+uv run orq-arena anchor outputs/g1/battles.jsonl votes-h1.json votes-h2.json
 ```
 
 ## `refresh-models`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -393,6 +393,8 @@ orq-arena annotate BATTLE_LOG [--out PATH] [--sample N] [--seed N]
 | `--sample N` | all rounds | Annotate a seeded random subset instead of every round. |
 | `--seed N` | `42` | Drives round order and per-round side flips; keep it if you want two raters on identical pages. |
 | `--exclude PATH` | none | votes.json file(s), repeatable: rounds already voted there are dropped, producing a resume page with only the remaining rounds (or a top-up page when growing a study). |
+| `--serve` | off | Prodigy-style local mode: serve the page at `http://127.0.0.1:<port>` instead of writing a file. Every vote saves automatically as `votes-<annotator>.json` next to the log (no download step); Ctrl-C stops the server and prints the anchor table for whatever was voted. Localhost-only by construction; for remote raters use the default file mode. |
+| `--port N` | `8765` | Port for `--serve`; `0` picks a free one. |
 
 The page is one self-contained HTML file (inline CSS/JS, no external assets, works from
 `file://`), so "deployment" is sending someone the file. It is **blind by construction**:
@@ -417,6 +419,8 @@ uv run orq-arena annotate outputs/g1/battles.jsonl --sample 60
 uv run orq-arena annotate battles.jsonl --out rater2.html --seed 42
 # resume: only the rounds dana hasn't voted yet
 uv run orq-arena annotate battles.jsonl --exclude votes-dana.json --out dana-round2.html
+# annotate your own run locally, votes save as you click, Ctrl-C prints the numbers
+uv run orq-arena annotate outputs/g1/battles.jsonl --serve --sample 60
 ```
 
 ## `anchor`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -392,6 +392,7 @@ orq-arena annotate BATTLE_LOG [--out PATH] [--sample N] [--seed N]
 | `--out PATH` | `annotate.html` | Destination HTML file. |
 | `--sample N` | all rounds | Annotate a seeded random subset instead of every round. |
 | `--seed N` | `42` | Drives round order and per-round side flips; keep it if you want two raters on identical pages. |
+| `--exclude PATH` | none | votes.json file(s), repeatable: rounds already voted there are dropped, producing a resume page with only the remaining rounds (or a top-up page when growing a study). |
 
 The page is one self-contained HTML file (inline CSS/JS, no external assets, works from
 `file://`), so "deployment" is sending someone the file. It is **blind by construction**:
@@ -414,6 +415,8 @@ order.
 ```bash
 uv run orq-arena annotate outputs/g1/battles.jsonl --sample 60
 uv run orq-arena annotate battles.jsonl --out rater2.html --seed 42
+# resume: only the rounds dana hasn't voted yet
+uv run orq-arena annotate battles.jsonl --exclude votes-dana.json --out dana-round2.html
 ```
 
 ## `anchor`

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -21,10 +21,12 @@ For every round, one prompt, two warriors, in a tournament:
    maximum-likelihood** fit across every round judged so far in the tournament; ties count as
    half a win each.
 5. Bradley-Terry produces one rating per warrior, anchored so the field's geometric mean sits at
-   1000, plus a 200-resample percentile **bootstrap 95% confidence interval** on every rating.
+   1000, plus a 200-resample percentile **bootstrap 95% confidence interval** on every rating,
+   and a **length-controlled rating** that refits the same rounds with the jury's length
+   preference priced out.
 6. Alongside the rating, the run reports how often judges agreed with each other (Fleiss'/Cohen's
-   κ) and how often each individual judge flipped between seat orders, public, per-judge
-   evidence of how much to trust that vote.
+   κ), how often each individual judge flipped between seat orders, and the jury's fitted
+   **length coefficient**, public, per-judge evidence of how much to trust that vote.
 
 The rest of this page is the detail behind those six steps, plus what an actual 8-warrior run
 measured.
@@ -282,7 +284,9 @@ Every run is seeded and manifested so its rating can be audited or re-derived af
   `<output>.run.json` immediately at tournament start (config hash, prompt hash, roster, judge
   panel, replacement judges, quorum, the installed `evaluatorq` version, `started_at`) and
   rewrites it at the end with `finished_at` plus the closing report's `mean_agreement`,
-  `error_rounds`, `rated_rounds`, `category_counts`, `fleiss`, and token totals.
+  `error_rounds`, `rated_rounds`, `category_counts`, `fleiss`, `length_coef` (the jury's fitted
+  length coefficient, see [Style control](#style-control-the-length-confound-priced-out)), and
+  token totals.
 - **Content-addressed hashes, not filenames**: `config_sha256` and `prompts_sha256` are SHA-256
   digests (first 16 hex characters) of the serialized config and the newline-joined prompt texts,
   so two runs against the same config and prompt content are provably comparable even if either
@@ -315,6 +319,33 @@ rejected by a quorum sized for the original run's larger panel.
 This is the project's answer to "how do I know the ranking isn't just an artifact of which judges
 I happened to pick?", swap the jury, keep the responses, and measure rank stability directly
 instead of asserting it.
+
+## Human anchor: does the panel agree with people?
+
+Everything above measures the panel against itself. The human-anchor workflow measures it
+against people, the accuracy claim reliability metrics cannot make:
+
+1. `orq-arena annotate <log>` renders the recorded rounds into one self-contained, **blind**
+   annotation page (`src/orq_arena/anchor.py`): no model names, no jury votes, no verdicts in the
+   payload; rounds shuffled and sides swapped per round under a seed; round keys are one-way
+   hashes. The same seat-order discipline applied to the jury applies to the human, a rater
+   can't favor a side or a model they can't identify. Send the file to 2-3 raters (guidelines,
+   round count, and a time estimate are shown up front; the rubric shown is `--criteria`,
+   default identical to the jury's default).
+2. Each rater's votes come back as `votes.json`, exported in the canonical A/B frame (the page
+   un-flips before export, so vote files are independent of presentation order).
+3. `orq-arena anchor <log> votes.json […]` treats each human as one more judge and reports,
+   per rater: **Cohen's κ vs the panel majority** (over rounds where the panel was decisive;
+   inconclusive rounds are excluded from κ but still feed the human Bradley-Terry fit),
+   the **Spearman correlation between the human-vote Bradley-Terry ranking and the panel's**,
+   and, with several raters, **inter-annotator κ** per pair.
+
+Read the numbers the same way as the jury metrics: κ says whether the panel's round-level
+verdicts track human preference; the rank correlation says whether disagreements, where they
+exist, actually move the leaderboard. One residual bias survives the blinding: a rater who
+works with these models daily may recognize a family's prose style, the same self-preference
+caveat the jury carries, so prefer raters who don't, and report who rated alongside the
+numbers.
 
 ## Measured evidence: what a real 8-model run measured
 
@@ -362,10 +393,12 @@ Stated plainly, so you can weigh them against your own use case:
   this page, but well below the 20-comparison-per-category floor within a single round-robin run
   (`match.max_rounds=5` draws only 5 prompts per match). Treat the shipped bank as a smoke test,
   not a rigorous benchmark, until you supply your own larger prompt set.
-- **No human-anchor study yet.** Nothing in this project currently correlates jury verdicts
-  against blinded human preference judgments. The Fleiss'/Cohen's κ numbers above measure *judges
-  agreeing with each other*, not *judges agreeing with people*, a self-consistent panel is not
-  the same claim as an accurate one.
+- **No human-anchor *results* yet.** The workflow now exists
+  ([Human anchor](#human-anchor-does-the-panel-agree-with-people): `annotate` + `anchor`), but
+  no study has been run and published against it. Until then the Fleiss'/Cohen's κ numbers
+  above still only measure *judges agreeing with each other*, not *judges agreeing with
+  people*, a self-consistent panel is not the same claim as an accurate one. Target: 50-100
+  rounds, 2-3 blind raters.
 - **Style control covers length only.** The len-ctrl rating (see
   [Style control](#style-control-the-length-confound-priced-out)) corrects for response length;
   markdown/formatting covariates (headers, lists, bold), which LMArena's full style control also

--- a/src/orq_arena/anchor.py
+++ b/src/orq_arena/anchor.py
@@ -15,6 +15,7 @@ import json
 import random
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Collection
 
 from .analysis.kappa import cohen_kappa_pairs
 from .data.schemas import BattleRecord
@@ -29,12 +30,21 @@ def record_key(rec: BattleRecord) -> str:
 
 
 def annotation_items(
-    records: list[BattleRecord], *, seed: int = 42, sample: int | None = None
+    records: list[BattleRecord], *, seed: int = 42, sample: int | None = None,
+    exclude: Collection[str] = (),
 ) -> list[dict]:
-    """Blinded page payload: canonical responses + per-round display flip."""
+    """Blinded page payload: canonical responses + per-round display flip.
+
+    ``exclude`` drops rounds by record key (Prodigy's --exclude move): pass
+    a rater's existing votes.json keys to build a resume page with only
+    their unvoted rounds.
+    """
     items = []
+    excluded = set(exclude)
     for rec in records:
         key = record_key(rec)
+        if key in excluded:
+            continue
         items.append({
             "k": key,
             "q": rec.prompt_text,

--- a/src/orq_arena/anchor.py
+++ b/src/orq_arena/anchor.py
@@ -86,14 +86,29 @@ header input{font:inherit;padding:4px 8px;border:1px solid var(--line);border-ra
 .gate button:disabled{opacity:.4;cursor:default}
 .gate .big{font-size:17px}
 .hidden{display:none}
+.nav{display:flex;flex-wrap:wrap;gap:4px;padding:10px 0 2px}
+.dot{width:13px;height:13px;border-radius:4px;cursor:pointer;
+  background:#e6e1d6;border:1px solid #d5cfc0}
+.dot.seen{background:#b3ac9c;border-color:#b3ac9c}
+.dot.voted{background:var(--teal);border-color:var(--teal)}
+.dot.tie{background:#c99a2e;border-color:#c99a2e}
+.dot.cur{outline:2px solid var(--a);outline-offset:1px}
+.legend{font-family:var(--mono);font-size:10.5px;color:var(--muted);padding-bottom:6px}
 """
 
 _PAGE_JS = r"""
 const D = JSON.parse(document.getElementById('data').textContent);
-let idx = 0; const votes = {};
+let idx = 0; const votes = {}; const seen = new Set();
 const cacheKey = 'orq-anchor:' + D.source + ':' + D.seed;
-try { Object.assign(votes, JSON.parse(localStorage.getItem(cacheKey) || '{}')); } catch (e) {}
+try {
+  const c = JSON.parse(localStorage.getItem(cacheKey) || '{}');
+  Object.assign(votes, c.v || {});
+  for (const k of c.s || []) seen.add(k);
+} catch (e) {}
 let downloaded = false;
+function cache(){
+  try{localStorage.setItem(cacheKey,JSON.stringify({v:votes,s:[...seen]}));}catch(e){}
+}
 
 function esc(s){return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
 function md(text){
@@ -132,29 +147,68 @@ function show(name){
   for(const v of ['intro','annotate','done'])
     document.getElementById('view-'+v).classList.toggle('hidden',v!==name);
   document.getElementById('bar').classList.toggle('hidden',name!=='annotate');
+  document.getElementById('nav').classList.toggle('hidden',name==='intro');
+  document.getElementById('legend').classList.toggle('hidden',name==='intro');
   if(name==='annotate')render();
   if(name==='done')renderDone();
 }
+function counts(){
+  const voted=Object.keys(votes).length;
+  const skipped=[...seen].filter(k=>!(k in votes)).length;
+  return {voted, skipped, left:D.items.length-voted-skipped};
+}
+function progText(prefix){
+  const c=counts();
+  return prefix+'  ·  voted '+c.voted+' · skipped '+c.skipped+' · left '+c.left;
+}
+function buildNav(){
+  const nav=document.getElementById('nav');
+  D.items.forEach((it,i)=>{
+    const d=document.createElement('span');
+    d.className='dot'; d.title='round '+(i+1);
+    d.onclick=()=>{idx=i;show('annotate');};
+    nav.appendChild(d);
+  });
+}
+function updateNav(){
+  const dots=document.getElementById('nav').children;
+  D.items.forEach((it,i)=>{
+    const v=votes[it.k];
+    dots[i].className='dot'
+      +(v==='tie'?' tie':v?' voted':seen.has(it.k)?' seen':'')
+      +(view==='annotate'&&i===idx?' cur':'');
+  });
+}
 function render(){
   const it=D.items[idx];
+  seen.add(it.k); cache();
   const l=it.f?it.b:it.a, r=it.f?it.a:it.b;
-  document.getElementById('prog').textContent=(idx+1)+' / '+D.items.length+
-    '  ·  voted '+Object.keys(votes).length;
+  document.getElementById('prog').textContent=progText((idx+1)+' / '+D.items.length);
   document.getElementById('prompt').innerHTML=md(it.q);
   document.getElementById('left').innerHTML='<h3>Response 1</h3>'+md(l);
   document.getElementById('right').innerHTML='<h3>Response 2</h3>'+md(r);
   const v=votes[it.k];
   document.getElementById('lpane').classList.toggle('voted',v===canon('left',it));
   document.getElementById('rpane').classList.toggle('voted',v===canon('right',it));
+  updateNav();
 }
 function renderDone(){
-  const n=Object.keys(votes).length, total=D.items.length;
-  document.getElementById('prog').textContent='done · voted '+n+' / '+total;
+  const c=counts(), total=D.items.length;
+  document.getElementById('prog').textContent=progText('done');
   document.getElementById('done-stats').textContent=
-    n+' of '+total+' rounds voted'+(n<total?' ('+(total-n)+' skipped)':'');
+    c.voted+' of '+total+' rounds voted'+(c.voted<total?' ('+(total-c.voted)+' skipped or unseen; click any dot above to finish them)':'');
   document.getElementById('done-hint').textContent=downloaded
     ? 'votes.json downloaded. Send it back to whoever sent you this file.'
     : 'One step left: download your votes and send the file back.';
+  updateNav();
+}
+function nextUnvoted(){
+  const total=D.items.length;
+  for(let s=1;s<=total;s++){
+    const i=(idx+s)%total;
+    if(!(D.items[i].k in votes)){idx=i;show('annotate');return;}
+  }
+  show('done');
 }
 function start(){
   const name=document.getElementById('annotator-in').value.trim();
@@ -163,7 +217,7 @@ function start(){
 }
 function vote(side){const it=D.items[idx];
   if(side==='skip'){delete votes[it.k];}else{votes[it.k]=canon(side,it);}
-  try{localStorage.setItem(cacheKey,JSON.stringify(votes));}catch(e){}
+  cache();
   if(idx<D.items.length-1){idx++;render();}
   else{show('done');}
 }
@@ -183,10 +237,12 @@ document.addEventListener('keydown',e=>{
   if(view==='intro'){ if(e.key==='Enter')start(); return; }
   if(view==='done'){
     if(e.key==='ArrowLeft'){idx=D.items.length-1;show('annotate');}
+    else if(e.key==='n')nextUnvoted();
     return;
   }
   if(e.key==='a')vote('left'); else if(e.key==='b')vote('right');
   else if(e.key==='t')vote('tie'); else if(e.key===' '){e.preventDefault();vote('skip');}
+  else if(e.key==='n')nextUnvoted();
   else if(e.key==='ArrowRight'){ if(idx<D.items.length-1){idx++;render();} else show('done'); }
   else if(e.key==='ArrowLeft'&&idx>0){idx--;render();}
 });
@@ -195,6 +251,7 @@ window.addEventListener('beforeunload',e=>{
 document.getElementById('n-items').textContent=D.items.length;
 document.getElementById('n-mins').textContent=Math.max(1,Math.round(D.items.length*45/60));
 document.getElementById('criteria').textContent=D.criteria;
+buildNav();
 show('intro');
 """
 
@@ -227,6 +284,10 @@ def render_annotate_page(
 <header><b>blind annotation</b>
 <input id="annotator" type="hidden">
 <span class="prog" id="prog"></span></header>
+<div class="nav hidden" id="nav"></div>
+<div class="legend hidden" id="legend">■ voted · <span style="color:#c99a2e">■</span> tie ·
+<span style="color:#b3ac9c">■</span> skipped · □ unseen · click any dot to jump ·
+<b>n</b> = next unvoted</div>
 
 <div id="view-intro" class="gate">
 <h2>Compare two AI answers, pick the better one</h2>
@@ -234,7 +295,9 @@ def render_annotate_page(
 model wrote which, and the sides are shuffled every round on purpose.</p>
 <p class="stats"><span id="n-items"></span> rounds · roughly <span id="n-mins"></span> min ·
 keys: <b>a</b> left better, <b>b</b> right better, <b>t</b> tie, <b>space</b> skip,
-arrows to move around</p>
+<b>n</b> next unvoted, arrows to move around</p>
+<p>A dot strip above the rounds shows where you are and what each round's state is
+(voted, tie, skipped, unseen); click any dot to jump to that round.</p>
 <h3>Guidelines</h3>
 <ul>
 <li>Read both responses fully before voting; don't reward the first or the longer one.</li>

--- a/src/orq_arena/anchor.py
+++ b/src/orq_arena/anchor.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 import hashlib
 import json
 import random
+import re
 from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Collection
 
@@ -116,8 +118,19 @@ try {
   for (const k of c.s || []) seen.add(k);
 } catch (e) {}
 let downloaded = false;
+// Served over http (orq-arena annotate --serve): votes also POST to /save
+// after every decision, so closing the tab loses nothing.
+const SERVED = location.protocol.indexOf('http') === 0;
+let savedToServer = false;
 function cache(){
   try{localStorage.setItem(cacheKey,JSON.stringify({v:votes,s:[...seen]}));}catch(e){}
+}
+function persist(){
+  if(!SERVED)return;
+  const name=document.getElementById('annotator').value||'anonymous';
+  fetch('/save',{method:'POST',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({schema:1,seed:D.seed,source:D.source,annotator:name,votes:votes})})
+    .then(r=>{savedToServer=r.ok;}).catch(()=>{savedToServer=false;});
 }
 
 function esc(s){return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
@@ -207,7 +220,11 @@ function renderDone(){
   document.getElementById('prog').textContent=progText('done');
   document.getElementById('done-stats').textContent=
     c.voted+' of '+total+' rounds voted'+(c.voted<total?' ('+(total-c.voted)+' skipped or unseen; click any dot above to finish them)':'');
-  document.getElementById('done-hint').textContent=downloaded
+  document.getElementById('done-hint').textContent=SERVED
+    ? (savedToServer||Object.keys(votes).length===0
+       ? 'Votes are saved on this machine automatically; you can close this tab.'
+       : 'Saving to the local server failed; use the download button instead.')
+    : downloaded
     ? 'votes.json downloaded. Send it back to whoever sent you this file.'
     : 'One step left: download your votes and send the file back.';
   updateNav();
@@ -227,7 +244,7 @@ function start(){
 }
 function vote(side){const it=D.items[idx];
   if(side==='skip'){delete votes[it.k];}else{votes[it.k]=canon(side,it);}
-  cache();
+  cache(); persist();
   if(idx<D.items.length-1){idx++;render();}
   else{show('done');}
 }
@@ -257,7 +274,7 @@ document.addEventListener('keydown',e=>{
   else if(e.key==='ArrowLeft'&&idx>0){idx--;render();}
 });
 window.addEventListener('beforeunload',e=>{
-  if(Object.keys(votes).length&&!downloaded)e.preventDefault();});
+  if(Object.keys(votes).length&&!downloaded&&!(SERVED&&savedToServer))e.preventDefault();});
 document.getElementById('n-items').textContent=D.items.length;
 document.getElementById('n-mins').textContent=Math.max(1,Math.round(D.items.length*45/60));
 document.getElementById('criteria').textContent=D.criteria;
@@ -422,7 +439,8 @@ def anchor_result(records, votesets: list[VoteSet]) -> dict:
             "n_kappa": pair["rounds"],
             "kappa": pair["kappa"],
             "kappa_label": pair["label"],
-            "spearman": spearman(panel_rank, human_rank),
+            # no co-voted rounds -> no ranking claim, not an alphabetical one
+            "spearman": spearman(panel_rank, human_rank) if co else float("nan"),
         })
 
     inter = []
@@ -449,3 +467,93 @@ def anchor_result(records, votesets: list[VoteSet]) -> dict:
         "panel_ranking": panel_rank,
         "unknown_keys": unknown,
     }
+
+
+_VOTE_KEYS = ("schema", "seed", "source", "annotator", "votes")
+
+
+def make_annotation_server(
+    page: str, votes_dir: Path, *, host: str = "127.0.0.1", port: int = 8765
+) -> ThreadingHTTPServer:
+    """Localhost-only serve mode (decision 30): the same blinded page, but
+    every vote POSTs to /save and lands as votes-<annotator>.json next to
+    the log. No auth surface: binds 127.0.0.1, two fixed routes, capped
+    body, sanitized filename, whitelisted payload keys.
+    """
+    written: set[Path] = set()
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_args) -> None:
+            pass  # keep the terminal quiet; votes are the signal
+
+        def do_GET(self) -> None:
+            if self.path in ("", "/"):
+                body = page.encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            else:
+                self.send_error(404)
+
+        def do_POST(self) -> None:
+            if self.path != "/save":
+                self.send_error(404)
+                return
+            size = int(self.headers.get("Content-Length") or 0)
+            if not 0 < size <= 5_000_000:
+                self.send_error(413)
+                return
+            try:
+                data = json.loads(self.rfile.read(size))
+                votes = {
+                    str(k): v for k, v in (data.get("votes") or {}).items()
+                    if v in _DECISIVE
+                }
+                slug = re.sub(
+                    r"[^a-z0-9-]+", "-", str(data.get("annotator") or "").lower()
+                ).strip("-") or "anonymous"
+            except (ValueError, AttributeError):
+                self.send_error(400)
+                return
+            payload = {k: data.get(k) for k in _VOTE_KEYS}
+            payload["votes"] = votes
+            path = votes_dir / f"votes-{slug}.json"
+            tmp = path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(payload, indent=1))
+            tmp.replace(path)
+            written.add(path)
+            self.send_response(204)
+            self.end_headers()
+
+    server = ThreadingHTTPServer((host, port), Handler)
+    server.votes_written = written  # type: ignore[attr-defined]
+    return server
+
+
+def render_anchor_result(result: dict) -> None:
+    """Rich table for `anchor` and for --serve's exit summary."""
+    from rich.console import Console
+    from rich.table import Table
+
+    t = Table(title="human anchor vs panel")
+    for col in ("annotator", "voted", "κ rounds", "κ vs panel", "label", "rank ρ"):
+        t.add_column(col)
+    for row in result["per_annotator"]:
+        t.add_row(
+            row["annotator"], str(row["n_voted"]), str(row["n_kappa"]),
+            "n/a" if row["kappa"] is None else f"{row['kappa']:.2f}",
+            row["kappa_label"],
+            "n/a" if row["spearman"] != row["spearman"] else f"{row['spearman']:.2f}",
+        )
+    console = Console()
+    console.print(t)
+    for pair in result["inter_annotator"]:
+        console.print(
+            f"inter-annotator {pair['pair']}: "
+            + ("κ=n/a" if pair["kappa"] is None else f"κ={pair['kappa']:.2f}")
+            + f" ({pair['kappa_label']}, {pair['rounds']} rounds)"
+        )
+    if result["unknown_keys"]:
+        console.print(f"⚠ {result['unknown_keys']} votes matched no round in this log")

--- a/src/orq_arena/cli.py
+++ b/src/orq_arena/cli.py
@@ -320,8 +320,11 @@ def refresh_models(config_path: str, show: bool) -> None:
 @click.option("--seed", type=int, default=42, show_default=True)
 @click.option("--criteria", default=None,
               help="Judging guidelines shown to the rater; default matches the jury's default.")
+@click.option("--exclude", "exclude_files", multiple=True, type=click.Path(exists=True),
+              help="votes.json to exclude already-voted rounds; repeat per file. "
+                   "Builds a resume page with only the remaining rounds.")
 def annotate(battle_log: str, out_path: str, sample: int | None, seed: int,
-             criteria: str | None) -> None:
+             criteria: str | None, exclude_files: tuple[str, ...]) -> None:
     """Render a blinded human-annotation page from a recorded run.
 
     The page is one self-contained HTML file: open it locally or send it
@@ -330,18 +333,27 @@ def annotate(battle_log: str, out_path: str, sample: int | None, seed: int,
     """
     from pathlib import Path
 
-    from .anchor import DEFAULT_CRITERIA, annotation_items, render_annotate_page
+    from .anchor import (DEFAULT_CRITERIA, annotation_items, load_votes,
+                         render_annotate_page)
     from .rejudge import load_records
 
     records = load_records(battle_log)
     if not records:
         raise click.ClickException(f"no judgeable rounds in {battle_log}")
-    items = annotation_items(records, seed=seed, sample=sample)
+    excluded: set[str] = set()
+    for vs in load_votes(list(exclude_files)):
+        excluded.update(vs.votes)
+    items = annotation_items(records, seed=seed, sample=sample, exclude=excluded)
+    if not items:
+        raise click.ClickException("every round is already voted in the --exclude files")
     Path(out_path).write_text(
         render_annotate_page(items, seed=seed, source=Path(battle_log).name,
                              criteria=criteria or DEFAULT_CRITERIA)
     )
-    click.echo(f"{len(items)} rounds -> {out_path} (blind; votes export as votes.json)")
+    click.echo(
+        f"{len(items)} rounds -> {out_path} (blind; votes export as votes.json)"
+        + (f", {len(excluded)} already-voted excluded" if excluded else "")
+    )
 
 
 @cli.command()

--- a/src/orq_arena/cli.py
+++ b/src/orq_arena/cli.py
@@ -323,8 +323,14 @@ def refresh_models(config_path: str, show: bool) -> None:
 @click.option("--exclude", "exclude_files", multiple=True, type=click.Path(exists=True),
               help="votes.json to exclude already-voted rounds; repeat per file. "
                    "Builds a resume page with only the remaining rounds.")
+@click.option("--serve", is_flag=True, default=False,
+              help="Serve the page on localhost instead of writing a file; votes save "
+                   "automatically next to the log. Ctrl-C prints the anchor numbers.")
+@click.option("--port", type=int, default=8765, show_default=True,
+              help="Port for --serve (0 picks a free one).")
 def annotate(battle_log: str, out_path: str, sample: int | None, seed: int,
-             criteria: str | None, exclude_files: tuple[str, ...]) -> None:
+             criteria: str | None, exclude_files: tuple[str, ...],
+             serve: bool, port: int) -> None:
     """Render a blinded human-annotation page from a recorded run.
 
     The page is one self-contained HTML file: open it locally or send it
@@ -346,10 +352,31 @@ def annotate(battle_log: str, out_path: str, sample: int | None, seed: int,
     items = annotation_items(records, seed=seed, sample=sample, exclude=excluded)
     if not items:
         raise click.ClickException("every round is already voted in the --exclude files")
-    Path(out_path).write_text(
-        render_annotate_page(items, seed=seed, source=Path(battle_log).name,
-                             criteria=criteria or DEFAULT_CRITERIA)
-    )
+    page = render_annotate_page(items, seed=seed, source=Path(battle_log).name,
+                                criteria=criteria or DEFAULT_CRITERIA)
+    if serve:
+        import webbrowser
+
+        from .anchor import anchor_result, make_annotation_server, render_anchor_result
+
+        server = make_annotation_server(page, Path(battle_log).parent, port=port)
+        url = f"http://127.0.0.1:{server.server_address[1]}"
+        click.echo(f"serving {len(items)} rounds at {url} (Ctrl-C when done)")
+        webbrowser.open(url)
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            pass
+        finally:
+            server.server_close()
+        files = sorted(server.votes_written)  # type: ignore[attr-defined]
+        if not files:
+            click.echo("\nno votes saved")
+            return
+        click.echo(f"\nvotes: {', '.join(str(f) for f in files)}")
+        render_anchor_result(anchor_result(records, load_votes(files)))
+        return
+    Path(out_path).write_text(page)
     click.echo(
         f"{len(items)} rounds -> {out_path} (blind; votes export as votes.json)"
         + (f", {len(excluded)} already-voted excluded" if excluded else "")
@@ -366,29 +393,9 @@ def anchor(battle_log: str, vote_files: tuple[str, ...]) -> None:
     correlation between the human and panel Bradley-Terry rankings, and
     inter-annotator κ when more than one vote file is given.
     """
-    from rich.console import Console
-    from rich.table import Table
-
-    from .anchor import anchor_result, load_votes
+    from .anchor import anchor_result, load_votes, render_anchor_result
     from .rejudge import load_records
 
-    result = anchor_result(load_records(battle_log), load_votes(list(vote_files)))
-    t = Table(title="human anchor vs panel")
-    for col in ("annotator", "voted", "κ rounds", "κ vs panel", "label", "rank ρ"):
-        t.add_column(col)
-    for row in result["per_annotator"]:
-        t.add_row(
-            row["annotator"], str(row["n_voted"]), str(row["n_kappa"]),
-            "n/a" if row["kappa"] is None else f"{row['kappa']:.2f}",
-            row["kappa_label"],
-            "n/a" if row["spearman"] != row["spearman"] else f"{row['spearman']:.2f}",
-        )
-    Console().print(t)
-    for pair in result["inter_annotator"]:
-        click.echo(
-            f"inter-annotator {pair['pair']}: "
-            + ("κ=n/a" if pair["kappa"] is None else f"κ={pair['kappa']:.2f}")
-            + f" ({pair['kappa_label']}, {pair['rounds']} rounds)"
-        )
-    if result["unknown_keys"]:
-        click.echo(f"⚠ {result['unknown_keys']} votes matched no round in this log")
+    render_anchor_result(
+        anchor_result(load_records(battle_log), load_votes(list(vote_files)))
+    )

--- a/tests/test_anchor_cli.py
+++ b/tests/test_anchor_cli.py
@@ -35,3 +35,19 @@ def test_anchor_prints_kappa_table(tmp_path):
     r = CliRunner().invoke(cli, ["anchor", str(log), str(votes)])
     assert r.exit_code == 0, r.output
     assert "h1" in r.output and "κ" in r.output
+
+
+def test_annotate_exclude_builds_resume_page(tmp_path):
+    log = _log(tmp_path)
+    votes = tmp_path / "votes.json"
+    votes.write_text(json.dumps({
+        "schema": 1, "seed": 42, "source": "battles.jsonl", "annotator": "h1",
+        "votes": {record_key(r): "A" for r in RECORDS[:4]},
+    }))
+    out = tmp_path / "resume.html"
+    r = CliRunner().invoke(
+        cli, ["annotate", str(log), "--out", str(out), "--exclude", str(votes)])
+    assert r.exit_code == 0, r.output
+    assert "2 rounds" in r.output and "4 already-voted excluded" in r.output
+    for rec in RECORDS[:4]:
+        assert rec.prompt_text not in out.read_text()

--- a/tests/test_anchor_items.py
+++ b/tests/test_anchor_items.py
@@ -41,3 +41,11 @@ def test_flip_is_seeded_per_key_and_mixed():
 
 def test_sample_truncates_after_shuffle():
     assert len(annotation_items(RECORDS, seed=7, sample=3)) == 3
+
+
+def test_exclude_drops_already_voted_keys():
+    keys = {record_key(r) for r in RECORDS[:2]}
+    items = annotation_items(RECORDS, seed=7, exclude=keys)
+    assert {i["k"] for i in items} == {record_key(r) for r in RECORDS[2:]}
+    # exclusion composes with sample (filter first, then truncate)
+    assert len(annotation_items(RECORDS, seed=7, exclude=keys, sample=2)) == 2

--- a/tests/test_anchor_math.py
+++ b/tests/test_anchor_math.py
@@ -63,3 +63,9 @@ def test_load_votes_roundtrip(tmp_path):
     }))
     (vs,) = load_votes([p])
     assert vs.annotator == "h1" and vs.votes[KEYS[1]] == "tie"
+
+
+def test_zero_covoted_rounds_yields_nan_spearman_not_alphabetical():
+    res = anchor_result(RECORDS, [_vs("h1", {"deadbeefdeadbeef": "A"})])
+    row = res["per_annotator"][0]
+    assert row["spearman"] != row["spearman"]  # NaN

--- a/tests/test_anchor_page.py
+++ b/tests/test_anchor_page.py
@@ -36,3 +36,10 @@ def test_page_has_intro_annotate_and_done_views():
         assert page.count(f'id="{view_id}"') == 1
     assert "Guidelines" in page and "Download votes.json" in page
     assert "Accuracy and correctness" in page  # default criteria reach the rater
+
+
+def test_page_has_round_navigator():
+    page = _page()
+    assert page.count('id="nav"') == 1 and page.count('id="legend"') == 1
+    for token in ("buildNav", "nextUnvoted", "skipped"):
+        assert token in page

--- a/tests/test_anchor_serve.py
+++ b/tests/test_anchor_serve.py
@@ -1,0 +1,80 @@
+"""Local serve mode: GET / serves the page, POST /save persists votes."""
+
+import json
+import threading
+import urllib.request
+
+from orq_arena.anchor import make_annotation_server
+
+
+def _server(tmp_path):
+    srv = make_annotation_server("<!doctype html>PAGE", tmp_path, port=0)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, f"http://127.0.0.1:{srv.server_address[1]}"
+
+
+def _post(url, payload) -> int:
+    req = urllib.request.Request(
+        url + "/save", data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"}, method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status
+    except urllib.error.HTTPError as e:
+        return e.code
+
+
+def test_get_serves_page_and_unknown_paths_404(tmp_path):
+    srv, url = _server(tmp_path)
+    try:
+        assert urllib.request.urlopen(url + "/").read() == b"<!doctype html>PAGE"
+        try:
+            urllib.request.urlopen(url + "/etc/passwd")
+            raise AssertionError("expected 404")
+        except urllib.error.HTTPError as e:
+            assert e.code == 404
+    finally:
+        srv.shutdown()
+
+
+def test_post_save_writes_sanitized_vote_file(tmp_path):
+    srv, url = _server(tmp_path)
+    try:
+        status = _post(url, {
+            "schema": 1, "seed": 42, "source": "x", "annotator": "Dana K!",
+            "votes": {"k1": "A", "k2": "bogus", "k3": "tie"},
+            "extra_field": "dropped",
+        })
+        assert status == 204
+        path = tmp_path / "votes-dana-k.json"
+        assert path in srv.votes_written
+        saved = json.loads(path.read_text())
+        assert saved["votes"] == {"k1": "A", "k3": "tie"}  # bogus filtered
+        assert "extra_field" not in saved
+    finally:
+        srv.shutdown()
+
+
+def test_post_bad_json_is_400_not_crash(tmp_path):
+    srv, url = _server(tmp_path)
+    try:
+        req = urllib.request.Request(
+            url + "/save", data=b"not json", method="POST")
+        try:
+            urllib.request.urlopen(req)
+            raise AssertionError("expected 400")
+        except urllib.error.HTTPError as e:
+            assert e.code == 400
+        assert not srv.votes_written
+    finally:
+        srv.shutdown()
+
+
+def test_page_has_serve_hook():
+    from orq_arena.anchor import annotation_items, render_annotate_page
+    from tests.test_anchor_items import RECORDS
+
+    page = render_annotate_page(
+        annotation_items(RECORDS, seed=7), seed=7, source="x")
+    assert "SERVED" in page and "'/save'" in page


### PR DESCRIPTION
## What

Iterates the G5 human-anchor annotation page from first-rater feedback, and adds the second transport (decisions 28-30):

- **Round navigator** (Prodigy-inspired): persistent voted/skipped/left counts in the header, a clickable per-round dot strip (voted / tie / seen-but-skipped / unseen / current), and `n` = jump to next unvoted round.
- **`annotate --exclude votes.json`**: resume pages containing only a rater's unvoted rounds; also covers growing a study without re-rating.
- **`annotate --serve`**: Prodigy-style localhost mode on stdlib `http.server` (127.0.0.1 only, no new dependencies). Every vote saves atomically as `votes-<annotator>.json` next to the log; Ctrl-C prints the anchor table. Static-file mode is unchanged and remains the transport for remote raters.
- Fix: an annotator with zero co-voted rounds now reports rank rho as n/a instead of an alphabetical-ranking artifact.

## Why

Closes the annotation-UX gaps found by actually using the page (no sense of position/progress, surprise auto-download, no resume path, download-dance for local self-annotation) while keeping the blinding contract test-enforced and the no-server property for remote raters.

## Verification

- 84 tests green (`uv run pytest`), including new server tests (GET/POST/sanitization/400s) and the exclude/resume path.
- Serve mode exercised end-to-end: start, GET page, POST vote, SIGINT, anchor table printed, vote file written next to the log.
- Page JS syntax-checked with node; the canonical flip/un-flip mapping verified against the shipped script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)